### PR TITLE
fix include path

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -2,7 +2,7 @@ package mdb
 
 /*
 #cgo LDFLAGS: -L/usr/local/lib -llmdb
-#cgo CFLAGS: -I/usr/local
+#cgo CFLAGS: -I/usr/local/include
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
The include path adds the parent directory of the $PREFIX/include
