### PR TITLE
txn.Get() uses a NULL return pointer.

### DIFF
--- a/mdb_test.go
+++ b/mdb_test.go
@@ -115,6 +115,15 @@ func TestTest1(t *testing.T) {
 		}
 	}
 	cursor.Close()
+	bval, err = txn.Get(dbi, []byte("Key-0"))
+	if err != nil {
+		txn.Abort()
+		t.Fatalf("Error during txn get %s", err)
+	}
+	if string(bval) != "Val-0" {
+		txn.Abort()
+		t.Fatalf("Invalid txn get %s", string(bval))
+	}
 	txn.Abort()
 }
 

--- a/txn.go
+++ b/txn.go
@@ -126,8 +126,8 @@ func (txn *Txn) Drop(dbi DBI, del int) error {
 func (txn *Txn) Get(dbi DBI, key []byte) ([]byte, error) {
 	ckey := &C.MDB_val{mv_size: C.size_t(len(key)),
 		mv_data: unsafe.Pointer(&key[0])}
-	var cval *C.MDB_val
-	ret := C.mdb_get(txn._txn, C.MDB_dbi(dbi), ckey, cval)
+	var cval C.MDB_val
+	ret := C.mdb_get(txn._txn, C.MDB_dbi(dbi), ckey, &cval)
 	if ret != SUCCESS {
 		return nil, Errno(ret)
 	}


### PR DESCRIPTION
The `txn.Get()` call was failing because the cval pointer is NULL. If you turn on `MDB_DEBUG` in the lmdb source then you can see the failed assertion. I just changed the code so that the `cval` is a local variable and its reference is passed to `mdb_get()`. The value gets copied out before the function ends so it shouldn't be a problem that it's local.
