### PR TITLE
Add low-level access to the LMDB cursor.

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -64,6 +64,11 @@ func (cursor *Cursor) DBI() DBI {
 	return DBI(_dbi)
 }
 
+// Retrieves the low-level MDB cursor.
+func (cursor *Cursor) MdbCursor() *C.MDB_cursor {
+	return cursor._cursor
+}
+
 func (cursor *Cursor) Get(set_key []byte, op uint) (key, val []byte, err error) {
 	var ckey C.MDB_val
 	var cval C.MDB_val


### PR DESCRIPTION
I'm passing off the LMDB cursor to a low-level C routine inside my application so I need to grab the reference to the actual low-level cursor. I didn't add a test since that seemed like overkill. :)
