### PR TITLE
Fixed edge case for Ubuntu 12.10

### DIFF
--- a/env.go
+++ b/env.go
@@ -194,7 +194,7 @@ func (env *Env) Path() (string, error) {
 	return C.GoString(cpath), nil
 }
 
-func (env *Env) SetMapSize(size uint) error {
+func (env *Env) SetMapSize(size uint64) error {
 	ret := C.mdb_env_set_mapsize(env._env, C.size_t(size))
 	if ret != SUCCESS {
 		return Errno(ret)


### PR DESCRIPTION
For some reason, Ubuntu 12.10 throws an integer overflow when passing `10 << 30`, while that works fine on a mac.

This fixes it.
