### PR TITLE
remove the FIXEDMAP flag from tests/examples

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -11,7 +11,7 @@ func TestEnvOpen(t *testing.T) {
 	if err != nil {
 		t.Errorf("Cannot create enviroment: %s", err)
 	}
-	err = env.Open("adsjgfadsfjg", FIXEDMAP, 0664)
+	err = env.Open("adsjgfadsfjg", 0, 0664)
 	if err == nil {
 		t.Errorf("should not be able to open")
 	}
@@ -23,7 +23,7 @@ func TestEnvOpen(t *testing.T) {
 	if err != nil {
 		t.Errorf("Cannot create directory: %s", path)
 	}
-	err = env.Open(path, FIXEDMAP, 0664)
+	err = env.Open(path, 0, 0664)
 	if err != nil {
 		t.Errorf("Cannot open environment: %s", err)
 	}
@@ -48,7 +48,7 @@ func setup(t *testing.T) *Env {
 	if err != nil {
 		t.Errorf("Cannot create directory: %s", path)
 	}
-	err = env.Open(path, FIXEDMAP, 0664)
+	err = env.Open(path, 0, 0664)
 	if err != nil {
 		t.Errorf("Cannot open environment: %s", err)
 	}

--- a/mdb_test.go
+++ b/mdb_test.go
@@ -25,7 +25,7 @@ func TestTest1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot create directory: %s", path)
 	}
-	err = env.Open(path, FIXEDMAP, 0664)
+	err = env.Open(path, 0, 0664)
 	defer env.Close()
 	if err != nil {
 		t.Fatalf("Cannot open environment: %s", err)
@@ -151,7 +151,7 @@ func TestTest2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot create directory: %s", path)
 	}
-	err = env.Open(path, FIXEDMAP, 0664)
+	err = env.Open(path, 0, 0664)
 	defer env.Close()
 	if err != nil {
 		t.Fatalf("Cannot open environment: %s", err)


### PR DESCRIPTION
FIXEDMAP can cause problems when databases are long-lived (longer than the process using it) and when the database needs to be read by other programs.
