### PR TITLE
Make gomdb statically linked

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,9 @@ GoDoc available here: http://godoc.org/github.com/szferi/gomdb
 Build
 =======
 
-`git clone -b mdb.master --single-branch git://git.openldap.org/openldap.git`
+`go get github.com/szferi/gomdb`
 
-`make`
-
-`make install`
-
-It will install to /usr/local
-
-`export LD_LIBRARY_PATH=/usr/local/lib`
-
-`go test -v`
-
-
+There is no dependency on LMDB dynamic library.
 
 TODO
 ======

--- a/val.go
+++ b/val.go
@@ -1,12 +1,12 @@
 package mdb
 
 /*
-#cgo LDFLAGS: -L/usr/local/lib -llmdb
+#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wbad-function-cast -O2 -g
 #cgo CFLAGS: -I/usr/local
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <lmdb.h>
+#include "lmdb.h"
 */
 import "C"
 


### PR DESCRIPTION
Currently it is impossible to `go get github.com/szferi/gomdb` without having `lmdb.h` and `lmdb` library installed:

```
root@7fc2488c2bcc:/bugaga# go get github.com/szferi/gomdb
# github.com/szferi/gomdb
/go/src/github.com/szferi/gomdb/val.go:9:18: error: lmdb.h: No such file or directory

root@7fc2488c2bcc:/bugaga# cp /go/src/github.com/szferi/gomdb/lmdb.h /usr/include/
root@7fc2488c2bcc:/bugaga# go get github.com/szferi/gomdb
# github.com/szferi/gomdb
/usr/bin/ld: cannot find -llmdb
collect2: ld returned 1 exit status
```

However `gomdb` repository _already_ includes the source code for `lmdb`, and only a small change is needed to remove the external dependency on `lmdb.h` and `lmdb`. This pull request proposes this change.

After applying the supplied patch, it will be possible to perform `go get github.com/szferi/gomdb` without having lmdb headers / library installed on the machine, just as it is possible right now with `go get github.com/Babazka/gomdb`.
