### PR TITLE
Fix tests broken by #206e1af.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -156,7 +156,7 @@ func BenchmarkCursorScanRDONLY(b *testing.B) {
 			defer cur.Close()
 			var count int64
 			for {
-				_, _, err := cur.Get(nil, NEXT)
+				_, _, err := cur.Get(nil, nil, NEXT)
 				if err == NotFound {
 					return
 				}
@@ -207,7 +207,7 @@ func BenchmarkCursorScanValRDONLY(b *testing.B) {
 			defer cur.Close()
 			var count int64
 			for {
-				_, _, err := cur.GetVal(nil, NEXT)
+				_, _, err := cur.GetVal(nil, nil, NEXT)
 				if err == NotFound {
 					return
 				}

--- a/example_test.go
+++ b/example_test.go
@@ -43,7 +43,7 @@ func Example() {
 	cursor, _ := txn.CursorOpen(dbi)
 	defer cursor.Close()
 	for {
-		bkey, bval, err := cursor.Get(nil, NEXT)
+		bkey, bval, err := cursor.Get(nil, nil, NEXT)
 		if err == NotFound {
 			break
 		}

--- a/mdb_test.go
+++ b/mdb_test.go
@@ -82,7 +82,7 @@ func TestTest1(t *testing.T) {
 	var bkey, bval []byte
 	var rc error
 	for {
-		bkey, bval, rc = cursor.Get(nil, NEXT)
+		bkey, bval, rc = cursor.Get(nil, nil, NEXT)
 		if rc != nil {
 			break
 		}


### PR DESCRIPTION
This fixes issue #26 All tests and benchmarks pass (MacBook Pro Retina, 2.3GHz i7, SSD):

```
~/go/src/github.com/szferi/gomdb [master ⚡] % go test -v
# github.com/szferi/gomdb
./mdb.c:8605:46: warning: data argument not used by format string [-Wformat-extra-args]
/usr/include/secure/_stdio.h:47:56: note: expanded from macro 'sprintf'
=== RUN TestEnvOpen
--- PASS: TestEnvOpen (0.00 seconds)
=== RUN TestEnvCopy
--- PASS: TestEnvCopy (0.00 seconds)
    env_test.go:67: Env path: /tmp/mdb_test749479226
=== RUN TestErrno
--- PASS: TestErrno (0.00 seconds)
=== RUN TestTest1
--- PASS: TestTest1 (0.00 seconds)
    mdb_test.go:67: &{PSize:4096 Depth:1 BranchPages:0 LeafPages:1 OverflowPages:0 Entries:10}
    mdb_test.go:91: Val: Val-0
    mdb_test.go:92: Key: Key-0
    mdb_test.go:91: Val: Val-1
    mdb_test.go:92: Key: Key-1
    mdb_test.go:91: Val: Val-2
    mdb_test.go:92: Key: Key-2
    mdb_test.go:91: Val: Val-3
    mdb_test.go:92: Key: Key-3
    mdb_test.go:91: Val: Val-4
    mdb_test.go:92: Key: Key-4
    mdb_test.go:91: Val: Val-5
    mdb_test.go:92: Key: Key-5
    mdb_test.go:91: Val: Val-6
    mdb_test.go:92: Key: Key-6
    mdb_test.go:91: Val: Val-7
    mdb_test.go:92: Key: Key-7
    mdb_test.go:91: Val: Val-8
    mdb_test.go:92: Key: Key-8
    mdb_test.go:91: Val: Val-9
    mdb_test.go:92: Key: Key-9
=== RUN TestVal
--- PASS: TestVal (0.00 seconds)
=== RUN: Example
--- PASS: Example (870.656us)
PASS
ok      github.com/szferi/gomdb 0.022s
~/go/src/github.com/szferi/gomdb [master ⚡] % go test -bench . 
# github.com/szferi/gomdb
./mdb.c:8605:46: warning: data argument not used by format string [-Wformat-extra-args]
/usr/include/secure/_stdio.h:47:56: note: expanded from macro 'sprintf'
PASS
BenchmarkTxnPut   500000          2387 ns/op
--- BENCH: BenchmarkTxnPut
    bench_test.go:301: initializing random source data
BenchmarkTxnGetRDONLY    1000000          1592 ns/op
BenchmarkTxnGetValRDONLY     1000000          1151 ns/op
BenchmarkCursorScanRDONLY         10     130547727 ns/op
BenchmarkCursorScanValRDONLY          50      34778472 ns/op
ok      github.com/szferi/gomdb 62.268s
```
