### PR TITLE
Create a []byte backed by array

### DIFF
--- a/val.go
+++ b/val.go
@@ -33,6 +33,11 @@ func Wrap(p []byte) Val {
 
 // If val is nil, a empty slice is retured.
 func (val Val) Bytes() []byte {
+	return C.GoBytes(val.mv_data, C.int(val.mv_size))
+}
+
+// If val is nil, a empty slice is retured.
+func (val Val) BytesNoCopy() []byte {
 	hdr := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(val.mv_data)),
 		Len:  int(val.mv_size),

--- a/val_test.go
+++ b/val_test.go
@@ -18,3 +18,18 @@ func TestVal(t *testing.T) {
 		t.Errorf("Bytes() not the same as original data: %q", p)
 	}
 }
+
+func TestValNoCopy(t *testing.T) {
+	orig := "hey hey"
+	val := Wrap([]byte(orig))
+
+	s := val.String()
+	if s != orig {
+		t.Errorf("String() not the same as original data: %q", s)
+	}
+
+	p := val.BytesNoCopy()
+	if string(p) != orig {
+		t.Errorf("Bytes() not the same as original data: %q", p)
+	}
+}


### PR DESCRIPTION
I think `C.GoBytes()` still makes a copy. This should actually give us zero-copy reads.
